### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/src/shtym/_version.py
+++ b/src/shtym/_version.py
@@ -1,3 +1,3 @@
 """Version information for shtym."""
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"


### PR DESCRIPTION
# Pull Request Overview

Bump version from 0.1.2 to 0.1.3.

## Changes

- Update version in `src/shtym/_version.py` from 0.1.2 to 0.1.3

## Related Issues

N/A

## Test Details

- Version export test passing

## Future Work

N/A

## Notes

This is a routine version bump for the next release.